### PR TITLE
Update ca4 status get

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -200,7 +200,7 @@ class HumidifierStatus:
 
         data = MyHumidifier.status()
         if model == 'zhimi.humidifier.ca4':
-	    if Parameters["Mode6"] == 'Debug':
+            if Parameters["Mode6"] == 'Debug':
                 Domoticz.Debug(str(data))
             self.power = data.power
             self.humidity = data.humidity

--- a/plugin.py
+++ b/plugin.py
@@ -198,7 +198,22 @@ class HumidifierStatus:
         model = str(model)
         MyHumidifier = humiExecute(AddressIP, token, model)
 
-        data = str(MyHumidifier.status())
+        data = MyHumidifier.status()
+        if model == 'zhimi.humidifier.ca4':
+	    if Parameters["Mode6"] == 'Debug':
+                Domoticz.Debug(str(data))
+            self.power = data.power
+            self.humidity = data.humidity
+            self.temperature = data.temperature
+            self.mode = data.mode
+            self.target_humidity = data.target_humidity
+            self.waterlevel = data.water_level
+            self.dry = data.dry
+            self.led_brightness = data.led_brightness
+            self.motor_speed = data.motor_speed
+            return
+
+        data = str(data)
         if Parameters["Mode6"] == 'Debug':
             Domoticz.Debug(data[:30] + " .... " + data[-30:])
         data = data[19:-2]


### PR DESCRIPTION
As commented in https://github.com/develop-dvs/domoticz-AirHumidifier2/issues/2 - status get does not work for `zhimi.humidifier.ca4` because of different struct type and shifted indexes. 

This change treats status as a struct and working.
Probably needs to be updated for all models, but I have not got them and could not test them.